### PR TITLE
removed missed PC for downwards compatibility

### DIFF
--- a/classes/class.ilJSXGraphPlugin.php
+++ b/classes/class.ilJSXGraphPlugin.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 /**
  * Class ilJSXGraphPlugin
  * @authors Saúl Díaz <info@surlabs.es>
- * @ilCtrl_isCalledBy ilJSXGraphPCPluginGUI
+ * @ilCtrl_isCalledBy ilJSXGraphPluginGUI
  */
 class ilJSXGraphPlugin extends ilPageComponentPlugin {
     public function getPluginName(): string {


### PR DESCRIPTION
Hey guys, sorry for bothering again. I missed the "PC" in @ilCtrl_isCalledBy in my last commit.